### PR TITLE
Add Karpenter IAM policies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,8 @@ export class Karpenter extends Construct {
           'ec2:DescribeInstanceTypeOfferings',
           'ec2:DescribeAvailabilityZones',
           'ssm:GetParameter',
+          'pricing:GetProducts',
+          'ec2:DescribeSpotPriceHistory',
         ],
         resources: ['*'],
       }),


### PR DESCRIPTION
IAM policy is missing `pricing:GetProducts` and `ec2:DescribeSpotPriceHistory`

`status code: 400, request id: ...; AccessDeniedException: User: arn:aws:sts::... is not authorized to perform: pricing:GetProducts because no identity-based policy allows the pricing:GetProducts action`

relevant PR https://github.com/aws-quickstart/cdk-eks-blueprints/pull/464

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*