### PR TITLE
Avoid just using namespace as it is there in multiple examples

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export class Karpenter extends Construct {
      * For the Karpenter controller to be able to talk to the AWS APIs, we need to set up a few
      * resources which will allow the Karpenter controller to use IAM Roles for Service Accounts
      */
-    const namespace = this.cluster.addManifest('namespace', {
+    const namespace = this.cluster.addManifest('karpenter-namespace', {
       apiVersion: 'v1',
       kind: 'Namespace',
       metadata: {


### PR DESCRIPTION
https://github.com/aws-samples/cdk-eks-karpenter/issues/106

It resolves this issue.

Avoid just using namespace as logical id in addManifest method as it is used in multiple examples where namespaces are created. 

Users who build their clusters from ground up using this addManifest might have many resources in their namespace which they might not be able to delete.

Many examples have this code -
const namespace = this.cluster.addManifest('namespace', {
      apiVersion: 'v1',
      kind: 'Namespace',
      metadata: {
        name: this.namespace,
      },
    });

Due to this the logical id will be common for many other operators which will lead to the error pointed out in the issue.

This will be a breaking change for many users upgrading to this code.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*