### PR TITLE
Adding ec2:DescribeImages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,7 @@ export class Karpenter extends Construct {
           'ssm:GetParameter',
           'pricing:GetProducts',
           'ec2:DescribeSpotPriceHistory',
+          'ec2:DescribeImages'
         ],
         resources: ['*'],
       }),


### PR DESCRIPTION
Adding ec2:DescribeImages permission for using Custom AMI

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

https://github.com/aws-samples/cdk-eks-karpenter/issues/108