### PR TITLE
fix: Add Karpenter IAM policy "ec2:DescribeImages"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ export class Karpenter extends Construct {
           'ec2:DescribeInstanceTypes',
           'ec2:DescribeInstanceTypeOfferings',
           'ec2:DescribeAvailabilityZones',
+          'ec2:DescribeImages',
           'ssm:GetParameter',
           'pricing:GetProducts',
           'ec2:DescribeSpotPriceHistory',


### PR DESCRIPTION
Hello Team,

After upgrading Karpenter to v0.28.1 Karpenter deployment is throwing error:

```
2023-07-07T10:29:43.971Z	ERROR	controller	Reconciler error ...  "error": "creating machine, creating instance, getting launch template configs, getting launch templates, describing images [{\n  Name: \"image-id\",\n  Values: [\n    \"ami-01169e6118f3d4570\",\n    \"ami-0608d87b24ca93821\",\n    \"ami-0608d87b24ca93821\",\n    \"ami-07bf1b3b5426537ed\",\n    \"\"\n  ]\n}], UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: 7e316853-176f-42cd-ae7d-5f6b856c92da"}
```

Seems that IAM policy is missing :
`ec2:DescribeImages`

I added this manually to the policy created by CDK and Karpenter deployment started working as expected.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*