### PR TITLE
fix: Change ServiceAccount name behavior

### DIFF
--- a/API.md
+++ b/API.md
@@ -162,6 +162,7 @@ Any object.
 | <code><a href="#cdk-eks-karpenter.Karpenter.property.helmExtraValues">helmExtraValues</a></code> | <code>any</code> | *No description.* |
 | <code><a href="#cdk-eks-karpenter.Karpenter.property.namespace">namespace</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-eks-karpenter.Karpenter.property.nodeRole">nodeRole</a></code> | <code>aws-cdk-lib.aws_iam.Role</code> | *No description.* |
+| <code><a href="#cdk-eks-karpenter.Karpenter.property.serviceAccountName">serviceAccountName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-eks-karpenter.Karpenter.property.version">version</a></code> | <code>string</code> | *No description.* |
 
 ---
@@ -218,6 +219,16 @@ public readonly nodeRole: Role;
 
 ---
 
+##### `serviceAccountName`<sup>Required</sup> <a name="serviceAccountName" id="cdk-eks-karpenter.Karpenter.property.serviceAccountName"></a>
+
+```typescript
+public readonly serviceAccountName: string;
+```
+
+- *Type:* string
+
+---
+
 ##### `version`<sup>Optional</sup> <a name="version" id="cdk-eks-karpenter.Karpenter.property.version"></a>
 
 ```typescript
@@ -249,6 +260,7 @@ const karpenterProps: KarpenterProps = { ... }
 | <code><a href="#cdk-eks-karpenter.KarpenterProps.property.helmExtraValues">helmExtraValues</a></code> | <code>any</code> | Extra values to pass to the Karpenter Helm chart. |
 | <code><a href="#cdk-eks-karpenter.KarpenterProps.property.namespace">namespace</a></code> | <code>string</code> | The Kubernetes namespace to install to. |
 | <code><a href="#cdk-eks-karpenter.KarpenterProps.property.nodeRole">nodeRole</a></code> | <code>aws-cdk-lib.aws_iam.Role</code> | Custom NodeRole to pass for Karpenter Nodes. |
+| <code><a href="#cdk-eks-karpenter.KarpenterProps.property.serviceAccountName">serviceAccountName</a></code> | <code>string</code> | The Kubernetes ServiceAccount name to use. |
 | <code><a href="#cdk-eks-karpenter.KarpenterProps.property.version">version</a></code> | <code>string</code> | The helm chart version to install. |
 
 ---
@@ -299,6 +311,19 @@ public readonly nodeRole: Role;
 - *Type:* aws-cdk-lib.aws_iam.Role
 
 Custom NodeRole to pass for Karpenter Nodes.
+
+---
+
+##### `serviceAccountName`<sup>Optional</sup> <a name="serviceAccountName" id="cdk-eks-karpenter.KarpenterProps.property.serviceAccountName"></a>
+
+```typescript
+public readonly serviceAccountName: string;
+```
+
+- *Type:* string
+- *Default:* karpenter
+
+The Kubernetes ServiceAccount name to use.
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,13 @@ export interface KarpenterProps {
   readonly namespace?: string;
 
   /**
+   * The Kubernetes ServiceAccount name to use
+   *
+   * @default karpenter
+   */
+  readonly serviceAccountName?: string;
+
+  /**
    * The helm chart version to install
    *
    * @default - latest
@@ -41,6 +48,7 @@ export interface KarpenterProps {
 export class Karpenter extends Construct {
   public readonly cluster: Cluster;
   public readonly namespace: string;
+  public readonly serviceAccountName: string;
   public readonly version?: string;
   public readonly nodeRole: Role;
   public readonly helmExtraValues: any;
@@ -52,6 +60,7 @@ export class Karpenter extends Construct {
 
     this.cluster = props.cluster;
     this.namespace = props.namespace ?? 'karpenter';
+    this.serviceAccountName = props.serviceAccountName ?? 'karpenter';
     this.version = props.version;
     this.helmExtraValues = props.helmExtraValues ?? {};
 
@@ -61,9 +70,8 @@ export class Karpenter extends Construct {
      *
      * We will also create a role mapping in the `aws-auth` ConfigMap so that the nodes can authenticate
      * with the Kubernetes API using IAM.
-     */
-
-    /* Create Node Role if nodeRole not added as prop
+     *
+     * Create Node Role if nodeRole not added as prop
      * Make sure that the Role that is added does not have an Instance Profile associated to it
      * since we will create it here.
     */
@@ -110,6 +118,7 @@ export class Karpenter extends Construct {
     });
 
     this.serviceAccount = this.cluster.addServiceAccount('karpenter', {
+      name: this.serviceAccountName,
       namespace: this.namespace,
     });
     this.serviceAccount.node.addDependency(namespace);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,7 +10,7 @@ describe('Karpenter installation', () => {
     const stack = new cdk.Stack(app, 'test-stack');
 
     const cluster = new Cluster(stack, 'testcluster', {
-      version: KubernetesVersion.V1_21,
+      version: KubernetesVersion.V1_27,
     });
 
     new Karpenter(stack, 'Karpenter', {
@@ -28,7 +28,7 @@ describe('Karpenter installation', () => {
     const stack = new cdk.Stack(app, 'test-stack');
 
     const cluster = new Cluster(stack, 'testcluster', {
-      version: KubernetesVersion.V1_21,
+      version: KubernetesVersion.V1_27,
     });
 
     // Create Karpenter install with non-default version
@@ -49,7 +49,7 @@ describe('Karpenter installation', () => {
     const stack = new cdk.Stack(app, 'test-stack');
 
     const cluster = new Cluster(stack, 'testcluster', {
-      version: KubernetesVersion.V1_21,
+      version: KubernetesVersion.V1_27,
     });
 
     // Create Karpenter install with non-default namespace
@@ -99,7 +99,7 @@ describe('Karpenter installation', () => {
     const stack = new cdk.Stack(app, 'test-stack');
 
     const cluster = new Cluster(stack, 'testcluster', {
-      version: KubernetesVersion.V1_24,
+      version: KubernetesVersion.V1_27,
     });
 
     const preexistingRole = new Role(stack, 'PreExistingRole', {
@@ -130,7 +130,7 @@ describe('Karpenter installation', () => {
     const stack = new cdk.Stack(app, 'test-stack');
 
     const cluster = new Cluster(stack, 'testcluster', {
-      version: KubernetesVersion.V1_24,
+      version: KubernetesVersion.V1_27,
     });
 
     // Create Karpenter install with non-default version
@@ -208,7 +208,7 @@ describe('Karpenter Versions', () => {
     const stack = new cdk.Stack(app, 'test-stack');
 
     const cluster = new Cluster(stack, 'testcluster', {
-      version: KubernetesVersion.V1_23,
+      version: KubernetesVersion.V1_27,
     });
 
     // Create Karpenter install with non-default version
@@ -229,7 +229,7 @@ describe('Karpenter Versions', () => {
     const stack = new cdk.Stack(app, 'test-stack');
 
     const cluster = new Cluster(stack, 'testcluster', {
-      version: KubernetesVersion.V1_23,
+      version: KubernetesVersion.V1_27,
     });
 
     // Create Karpenter install with non-default version


### PR DESCRIPTION
As discussed in #136, this PR adds a property to the construct exposing `serviceAccountName`, and sets the default name to `karpenter`.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*