### PR TITLE
fix: update IAM policy to match the latest version for Karpenter v0.33.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -502,6 +502,7 @@ export class Karpenter extends Construct {
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:volume/*`,
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:network-interface/*`,
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:launch-template/*`,
+        `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:spot-instances-request/*`,
       ],
       actions: [
         'ec2:RunInstances',
@@ -534,6 +535,7 @@ export class Karpenter extends Construct {
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:volume/*`,
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:network-interface/*`,
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:launch-template/*`,
+        `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:spot-instances-request/*`,
       ],
       actions: ['ec2:CreateTags'],
       conditions: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -482,7 +482,6 @@ export class Karpenter extends Construct {
       resources: [
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}::image/*`,
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}::snapshot/*`,
-        `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:spot-instances-request/*`,
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:security-group/*`,
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:subnet/*`,
         `arn:${Aws.PARTITION}:ec2:${Aws.REGION}:*:launch-template/*`,


### PR DESCRIPTION
adds permissions for AllowScopedEC2InstanceActionsWithTags and AllowScopedEC2InstanceActions for spot.

Fixes #150.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*