### PR TITLE
docs(utils) remove typos in validateKubernetesNameConformance documention

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  */
 export class Utils {
   /**
-   * Check wether or not a string conforms to the lowercase RFC 1123. If not, Kubernetes will throws
+   * Check whether a string conforms to the lowercase RFC 1123. If not, Kubernetes will throw
    * an error saying that the name must conform with regex used for validation, which is:
    * \'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\')\n'
    *


### PR DESCRIPTION
There are two minor issues with the documentation of the `validateKubernetesNameConformance` function.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*