### PR TITLE
feat!: Do not create a namespace if it is being installed into kube-system

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ const cluster = new Cluster(this, 'testCluster', {
 });
 
 const karpenter = new Karpenter(this, 'Karpenter', {
-  cluster: cluster
+  cluster: cluster,
+  namespace: "kube-system"
 });
 ```
 
@@ -34,6 +35,9 @@ also need to create an [EC2NodeClass](https://karpenter.sh/docs/concepts/nodecla
 [test/integ.karpenter.ts](./test/integ.karpenter.ts).
 
 ## Known issues
+
+### It is now a best practice to install Karpenter into the kube-system namespace:
+Kapenter CRD webhooks have 'kube-system' hard-coded into them, and do not work in other namespaces (such as 'karpenter')
 
 ### Versions earlier than v0.6.1 fails to install
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,19 +121,12 @@ export class Karpenter extends Construct {
      * For the Karpenter controller to be able to talk to the AWS APIs, we need to set up a few
      * resources which will allow the Karpenter controller to use IAM Roles for Service Accounts
      */
-    const namespace = this.cluster.addManifest('karpenter-namespace', {
-      apiVersion: 'v1',
-      kind: 'Namespace',
-      metadata: {
-        name: this.namespace,
-      },
-    });
 
     this.serviceAccount = this.cluster.addServiceAccount('karpenter', {
       name: this.serviceAccountName,
       namespace: this.namespace,
     });
-    this.serviceAccount.node.addDependency(namespace);
+    
 
     // Setup the controller IAM Policy statements
     this.addControllerPolicyIAMPolicyStatements();
@@ -198,7 +191,23 @@ export class Karpenter extends Construct {
       // will override the dynamic values.
       values: { ...this.helmExtraValues, ...this.helmChartValues },
     });
-    this.chart.node.addDependency(namespace);
+    
+
+    // If we are not installing it in the `kube-system` namespace:
+    // Note: We should be installing it in kube-system, please see: https://github.com/aws/karpenter-provider-aws/blob/fd2b60759f81dc0c868810cc44443103067c4880/website/content/en/v0.36/upgrading/upgrade-guide.md?plain=1#L91
+    // Also see https://github.com/aws-samples/cdk-eks-karpenter/issues/189 and https://github.com/aws-samples/cdk-eks-karpenter/issues/173
+    if (this.namespace != 'kube-system') {
+      const namespace = this.cluster.addManifest('karpenter-namespace', {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: {
+          name: this.namespace,
+        },
+      });
+      // If we are creating a namespace, we need to link it to the service account and the chart, so they are deployed in the correct order. 
+      this.serviceAccount.node.addDependency(namespace);
+      this.chart.node.addDependency(namespace);
+    }
   }
 
   /**


### PR DESCRIPTION
This change checks that the namespace Karpenter is being deployed to is not kube-system. If it is kube-system we don't try and create it. If it is anything else, we create it and create relevant dependancies in CFN. Please see the following for more information:

https://github.com/aws/karpenter-provider-aws/blob/fd2b60759f81dc0c868810cc44443103067c4880/website/content/en/v0.36/upgrading/upgrade-guide.md?plain=1#L91

https://github.com/aws-samples/cdk-eks-karpenter/issues/189 and https://github.com/aws-samples/cdk-eks-karpenter/issues/173



---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*