### PR TITLE
fix: upload-artifact breaking change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           name: .repo.patch
           path: .repo.patch
+          include-hidden-files: true
       - name: Fail build on mutation
         if: steps.self_mutation.outputs.self_mutation_happened
         run: |-
@@ -52,6 +53,7 @@ jobs:
         with:
           name: build-artifact
           path: dist
+          include-hidden-files: true
   self-mutation:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: .repo.patch
           path: ${{ runner.temp }}
@@ -93,7 +93,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: build-artifact
           path: dist
@@ -121,7 +121,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           git diff --staged --patch --exit-code > .repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: .repo.patch
           path: .repo.patch
@@ -48,7 +48,7 @@ jobs:
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: build-artifact
           path: dist
@@ -66,7 +66,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.4.3
         with:
           name: .repo.patch
           path: ${{ runner.temp }}
@@ -93,7 +93,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.4.3
         with:
           name: build-artifact
           path: dist
@@ -121,7 +121,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.4.3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch
-        uses: actions/download-artifact@v4.4.3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: .repo.patch
           path: ${{ runner.temp }}
@@ -93,7 +93,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.4.3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: build-artifact
           path: dist
@@ -121,7 +121,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.4.3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: build-artifact
           path: dist
@@ -86,7 +86,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: build-artifact
           path: dist
@@ -122,7 +122,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           name: build-artifact
           path: dist
+          include-hidden-files: true
   release_github:
     name: Publish to GitHub Releases
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: build-artifact
           path: dist
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.4.3
         with:
           name: build-artifact
           path: dist
@@ -86,7 +86,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.4.3
         with:
           name: build-artifact
           path: dist
@@ -122,7 +122,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.4.3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.4.3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: build-artifact
           path: dist
@@ -86,7 +86,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.4.3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: build-artifact
           path: dist
@@ -122,7 +122,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Download build artifacts
-        uses: actions/download-artifact@v4.4.3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: build-artifact
           path: dist

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -63,4 +63,6 @@ project.addTask('test:synth', {
   exec: 'npx cdk synth -a "npx ts-node -P tsconfig.dev.json --prefer-ts-exts test/integ.karpenter.ts"',
 });
 
+project.github.actions.set('actions/download-artifact', 'actions/download-artifact@v4.1.7');
+
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -71,7 +71,7 @@ build_workflow = project.tryFindObjectFile('.github/workflows/build.yml');
 build_workflow.patch(JsonPatch.add('/jobs/build/steps/5/with/include-hidden-files', true))
 build_workflow.patch(JsonPatch.add('/jobs/build/steps/8/with/include-hidden-files', true))
 
-build_workflow = project.tryFindObjectFile('.github/workflows/release.yml');
-build_workflow.patch(JsonPatch.add('/jobs/release/steps/7/with/include-hidden-files', true))
+release_workflow = project.tryFindObjectFile('.github/workflows/release.yml');
+release_workflow.patch(JsonPatch.add('/jobs/release/steps/7/with/include-hidden-files', true))
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -68,10 +68,10 @@ project.github.actions.set('actions/upload-artifact', 'actions/upload-artifact@v
 
 // https://github.com/actions/upload-artifact/issues/602
 build_workflow = project.tryFindObjectFile('.github/workflows/build.yml');
-build_workflow.patch(JsonPatch.add('/jobs/build/steps/5/with/include-hidden-files', true))
-build_workflow.patch(JsonPatch.add('/jobs/build/steps/8/with/include-hidden-files', true))
+build_workflow.patch(JsonPatch.add('/jobs/build/steps/5/with/include-hidden-files', true));
+build_workflow.patch(JsonPatch.add('/jobs/build/steps/8/with/include-hidden-files', true));
 
 release_workflow = project.tryFindObjectFile('.github/workflows/release.yml');
-release_workflow.patch(JsonPatch.add('/jobs/release/steps/7/with/include-hidden-files', true))
+release_workflow.patch(JsonPatch.add('/jobs/release/steps/7/with/include-hidden-files', true));
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,4 +1,4 @@
-const { awscdk } = require('projen');
+const { awscdk, JsonPatch } = require('projen');
 const { DependabotScheduleInterval } = require('projen/lib/github');
 
 const PROJECT_NAME = 'cdk-eks-karpenter';
@@ -65,5 +65,13 @@ project.addTask('test:synth', {
 
 project.github.actions.set('actions/download-artifact', 'actions/download-artifact@v4.1.8');
 project.github.actions.set('actions/upload-artifact', 'actions/upload-artifact@v4.4.3');
+
+// https://github.com/actions/upload-artifact/issues/602
+build_workflow = project.tryFindObjectFile('.github/workflows/build.yml');
+build_workflow.patch(JsonPatch.add('/jobs/build/steps/5/with/include-hidden-files', true))
+build_workflow.patch(JsonPatch.add('/jobs/build/steps/8/with/include-hidden-files', true))
+
+build_workflow = project.tryFindObjectFile('.github/workflows/release.yml');
+build_workflow.patch(JsonPatch.add('/jobs/release/steps/7/with/include-hidden-files', true))
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -63,6 +63,7 @@ project.addTask('test:synth', {
   exec: 'npx cdk synth -a "npx ts-node -P tsconfig.dev.json --prefer-ts-exts test/integ.karpenter.ts"',
 });
 
-project.github.actions.set('actions/download-artifact', 'actions/download-artifact@v4.1.7');
+project.github.actions.set('actions/download-artifact', 'actions/download-artifact@v4.4.3');
+project.github.actions.set('actions/upload-artifact', 'actions/upload-artifact@v4.4.3');
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -63,7 +63,7 @@ project.addTask('test:synth', {
   exec: 'npx cdk synth -a "npx ts-node -P tsconfig.dev.json --prefer-ts-exts test/integ.karpenter.ts"',
 });
 
-project.github.actions.set('actions/download-artifact', 'actions/download-artifact@v4.4.3');
+project.github.actions.set('actions/download-artifact', 'actions/download-artifact@v4.1.8');
 project.github.actions.set('actions/upload-artifact', 'actions/upload-artifact@v4.4.3');
 
 project.synth();


### PR DESCRIPTION
_Edit: Looks like underlying problem is that `upload-artifact` pushed silent breaking change: https://github.com/actions/upload-artifact/issues/602_

This restores `actions/download-artifact` in Github workflow to newer version used in https://github.com/aws-samples/cdk-eks-karpenter/pull/185, but pins it in `.projenrc.js` so it doesn't revert to old versions when you run `npx projen`.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*