### PR TITLE
fix: remove hard coding of InstanceProfileName

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,6 @@ export class Karpenter extends Construct {
 
     const instanceProfile = new CfnInstanceProfile(this, 'InstanceProfile', {
       roles: [this.nodeRole.roleName],
-      instanceProfileName: `${this.cluster.clusterName}-${id}`, // Must be specified to avoid CFN error
     });
 
     this.cluster.awsAuth.addRoleMapping(this.nodeRole, {


### PR DESCRIPTION
As identified in issue #214, hard coding the InstanceProfileName can cause issues. This commit changes the behavior as the hard coding of the name is no longer necessary.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*