### PR TITLE
fix: keep helmExtraValues.settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,7 @@ export class Karpenter extends Construct {
     }
     if (semver.gte(this.version, 'v0.32.0')) {
       this.helmChartValues.settings = {
+        ...this.helmExtraValues.settings,
         clusterName: this.cluster.clusterName,
         clusterEndpoint: this.cluster.clusterEndpoint,
         interruptionQueue: this.interruptionQueue?.queueName,


### PR DESCRIPTION
Keep user's `helmExtraValues.settings` when setting `helmChartValues.settings`.

I wasn't using the SpotToSpot feature gate, but wanted to start using the newer AutoRepair with:

```typescript
helmExtraValues: {
  settings: {
    featureGates: {
      nodeRepair: true
    }
  }
},
```

Follow-up https://github.com/aws-samples/cdk-eks-karpenter/issues/162 and https://github.com/aws-samples/cdk-eks-karpenter/pull/168